### PR TITLE
fix: ensure .js present in system.fileExtensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { STORYBOOK_IFRAME_PATH } from "./constants";
 import { getStorybookPathEndingWith } from "./utils";
 import { getStories } from "./storybook/get-stories";
 import { buildStoryTestFiles } from "./storybook/story-to-test";
-import { patchTestplaneBaseUrl, patchTestplaneSets, disableTestplaneIsolation } from "./utils";
+import { patchTestplaneBaseUrl, patchTestplaneSets, patchSystemExtensions, disableTestplaneIsolation } from "./utils";
 import { getStorybookDevServer } from "./storybook/dev-server";
 import type { PluginConfig, PluginPartialConfig } from "./config";
 import type { ExecutionContextExtended } from "./storybook/story-test-runner/types";
@@ -82,6 +82,7 @@ function onTestplaneMaster(testplane: Testplane, config: PluginConfig): void {
 
         patchTestplaneBaseUrl(testplane.config, iframeUrl);
         disableTestplaneIsolation(testplane.config, config.browserIds);
+        patchSystemExtensions(testplane.config);
         patchTestplaneSets(testplane.config, {
             browserIds: config.browserIds,
             files: storyTestFiles,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,6 +6,7 @@ import {
     patchTestplaneSets,
     disableTestplaneIsolation,
     patchTestplaneBaseUrl,
+    patchSystemExtensions,
 } from "./utils";
 
 describe("utils", () => {
@@ -49,6 +50,32 @@ describe("utils", () => {
             const expectedUrl = "http://localhost:6006/unknown-ending/new-ending";
 
             expect(getStorybookPathEndingWith(url, pathEnding)).toBe(expectedUrl);
+        });
+    });
+
+    describe("patchSystemExtensions", () => {
+        it("should add .js, if it is not present in system.fileExtensions", () => {
+            const config = getConfig_({
+                system: {
+                    fileExtensions: [".ts"],
+                },
+            });
+
+            patchSystemExtensions(config);
+
+            expect(config.system.fileExtensions).toEqual([".ts", ".js"]);
+        });
+
+        it("should not .js, if it is already present in system.fileExtensions", () => {
+            const config = getConfig_({
+                system: {
+                    fileExtensions: [".js", ".mjs"],
+                },
+            });
+
+            patchSystemExtensions(config);
+
+            expect(config.system.fileExtensions).toEqual([".js", ".mjs"]);
         });
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,12 @@ export const getStorybookPathEndingWith = (url: string, pathEnding: string): str
     return urlObj.toString();
 };
 
+export const patchSystemExtensions = (config: Config): void => {
+    if (!config.system.fileExtensions.includes(".js")) {
+        config.system.fileExtensions.push(".js");
+    }
+};
+
 export const patchTestplaneSets = (
     config: Config,
     {


### PR DESCRIPTION
If `system.fileExtensions` is declared with `[".ts"]`, when launching `testplane --storybook` user might encounter "No tests found" error